### PR TITLE
add setContent to keditor.js

### DIFF
--- a/src/js/keditor.js
+++ b/src/js/keditor.js
@@ -1709,6 +1709,16 @@
             });
         },
         
+      setContent: function(data) {
+          var target = $(this);
+          flog('setContent KEditor', target, data);
+          var keditor = target.data('keditor');
+          target.html(data);
+          var body = keditor.body;
+          body.removeClass('initialized-click-event-handlers');
+          KEditor.prototype.init.call(keditor, target);
+        },
+
         getContent: function (inArray) {
             var target = $(this);
             var keditor = target.data('keditor');


### PR DESCRIPTION
The purpose of setContent is to set an existing content dynamically. This allows for greater persistency.  

This is an initial setContent.  It reformats content nicely to the original.    The current and major problem is that I am not able to drop containers and components to the existing content area.  I notice that when I drop a container onto an existing container I am able to drop components to that particular container.  I am not able to drop new containers. Kindly advise.


