### PR TITLE
fix assign same generateId to keditor section

### DIFF
--- a/dist/js/keditor.js
+++ b/dist/js/keditor.js
@@ -211,6 +211,9 @@
     
     KEditor.prototype.generateId = function (type) {
         var timestamp = (new Date()).getTime();
+        if (timestamp === this.generateId.last)
+            this.generateId(type);
+        this.generateId.last = timestamp;
         return 'keditor-' + type + '-' + timestamp;
     };
     


### PR DESCRIPTION
some times generateId function assign same timestamp to keditor section, so that is fixed!